### PR TITLE
Improved writing for LigninBuilder

### DIFF
--- a/ligning/monomer.py
+++ b/ligning/monomer.py
@@ -276,7 +276,7 @@ class Monomer():
         self.G = G_m
 
         # Initialize a big graph for monomer
-        bigG = nx.DiGraph()
+        bigG = nx.Graph()
         bigG.add_node(self.mi, mtype = self.type, color = default_color[self.type])
         self.bigG = bigG
         

--- a/ligning/monomer.py
+++ b/ligning/monomer.py
@@ -276,7 +276,7 @@ class Monomer():
         self.G = G_m
 
         # Initialize a big graph for monomer
-        bigG = nx.Graph()
+        bigG = nx.DiGraph()
         bigG.add_node(self.mi, mtype = self.type, color = default_color[self.type])
         self.bigG = bigG
         

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -896,7 +896,8 @@ class Polymer(PolymerGraph):
         
         return new_linkage_flag
 
-    def write_LigninBuilder( name: Optional[str]='test',
+    def write_LigninBuilder(self,
+        name: Optional[str]='test',
         segname: Optional[str]='L',
         save_path: Optional[str]=os.getcwd()) -> None:
         """Convert this polymer to a Tcl script that VMD and LigninBuilder can convert to a 3D structure

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -475,7 +475,10 @@ class Polymer(PolymerGraph):
             self.G = PG_temp.G
             # Update the polymer big graph
             if monomer_new is not None:
-                self.bigG = ut.join_two(self.bigG, monomer_new.bigG)
+                if linkage_index[0] < linkage_index[1]:
+                    self.bigG = ut.join_two(self.bigG, monomer_new.bigG)
+                else:
+                    self.bigG = ut.join_two(monomer_new.bigG, self.bigG)
             # Update the avaible C1 list after addition of a new monomer and a new linkage  
             self.C1_indices_in_polymer = self.find_available_C1_in_polymer()
             # Update the unit dictionary

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -221,6 +221,7 @@ class PolymerGraph():
         # Define the edge properties
         #new bond as carbon/oxygen indices
         linkage_new = linkage_index 
+        print(linkage_new)
         C1_node = self.G.nodes[C1_index_in_polymer]
         C2_node = self.G.nodes[C2_index_in_polymer]
         
@@ -422,6 +423,7 @@ class Polymer(PolymerGraph):
         M2_index = self.G.nodes[C2_index_in_polymer]['mi']
 
         # Add the edges to monomer nodes
+        print(linkage_new_name, M1_index, M2_index)
         self.bigG.add_edges_from([(M1_index, M2_index)], btype=linkage_new_name)
 
 
@@ -463,10 +465,10 @@ class Polymer(PolymerGraph):
         if monomer_new is not None:
             monomer_new.create()
             PG_temp.G = ut.join_two(PG_temp.G, monomer_new.G)
-        
+        print("Linkage index", linkage_index)
         # Add the linkage
         new_linkage_flag = PG_temp.connect_C1_C2(linkage_index, C1_index_in_polymer, C2_index_in_polymer)
-        
+        print("New Linkage Flag")
         # If a new linakge does form
         if new_linkage_flag: 
             # Update the polymer graph

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -949,7 +949,7 @@ class Polymer(PolymerGraph):
                 elif H.edges[ei]['btype'] == 'beta-beta':
                     fout.write("patch BB %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
                 elif H.edges[ei]['btype'] == 'beta-1':
-                    fout.write("patch B1 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
+                    fout.write("patch B1 %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
             fout.write("writepsf %s.psf\n" % segname)
 
 

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -920,7 +920,7 @@ class Polymer(PolymerGraph):
                "topology toppar/top_spirodienone.top\n")
             # Write monomers
             fout.write("resetpsf\nsegment %s {\n" % segname)
-            for i in range(len(G.nodes)):
+            for i in range(len(H.nodes)):
                 if H.nodes[i]['mtype'] == 'G':
                     monomer = "GUAI"
                 elif H.nodes[i]['mtype'] == 'C':

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -424,7 +424,10 @@ class Polymer(PolymerGraph):
 
         # Add the edges to monomer nodes
         print(linkage_new_name, M1_index, M2_index)
-        self.bigG.add_edges_from([(M1_index, M2_index)], btype=linkage_new_name)
+        if linkage[0] <= linkage[1]:
+            self.bigG.add_edges_from([(M1_index, M2_index)], btype=linkage_new_name)
+        else:
+            self.bigG.add_edges_from([(M2_index, M1_index)], btype=linkage_new_name)
 
 
     def try_adding_new(
@@ -475,10 +478,7 @@ class Polymer(PolymerGraph):
             self.G = PG_temp.G
             # Update the polymer big graph
             if monomer_new is not None:
-                if linkage_index[0] < linkage_index[1]:
-                    self.bigG = ut.join_two(self.bigG, monomer_new.bigG)
-                else:
-                    self.bigG = ut.join_two(monomer_new.bigG, self.bigG)
+                self.bigG = ut.join_two(self.bigG, monomer_new.bigG)
             # Update the avaible C1 list after addition of a new monomer and a new linkage  
             self.C1_indices_in_polymer = self.find_available_C1_in_polymer()
             # Update the unit dictionary

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -131,7 +131,6 @@ class PolymerGraph():
 
         if ring:
             C2_indices_in_monmer = [ci for ci in C2_indices_in_monmer if ci != 1]
-        #print(C2_indices_in_monmer)
 
         return C2_indices_in_monmer
 
@@ -221,7 +220,6 @@ class PolymerGraph():
         # Define the edge properties
         #new bond as carbon/oxygen indices
         linkage_new = linkage_index 
-        print(linkage_new)
         C1_node = self.G.nodes[C1_index_in_polymer]
         C2_node = self.G.nodes[C2_index_in_polymer]
         
@@ -423,7 +421,6 @@ class Polymer(PolymerGraph):
         M2_index = self.G.nodes[C2_index_in_polymer]['mi']
 
         # Add the edges to monomer nodes
-        print(linkage_new_name, M1_index, M2_index)
         if linkage_index[0] <= linkage_index[1]:
             self.bigG.add_edges_from([(M1_index, M2_index)], btype=linkage_new_name)
         else:
@@ -468,10 +465,8 @@ class Polymer(PolymerGraph):
         if monomer_new is not None:
             monomer_new.create()
             PG_temp.G = ut.join_two(PG_temp.G, monomer_new.G)
-        print("Linkage index", linkage_index)
         # Add the linkage
         new_linkage_flag = PG_temp.connect_C1_C2(linkage_index, C1_index_in_polymer, C2_index_in_polymer)
-        print("New Linkage Flag")
         # If a new linakge does form
         if new_linkage_flag: 
             # Update the polymer graph
@@ -946,8 +941,6 @@ class Polymer(PolymerGraph):
                     fout.write("patch BO4 %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
                 elif H.edges[ei]['btype'] == '5-5':
                     fout.write("patch 55 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
-                elif H.edges[ei]['btype'] == '5-5':
-                    fout.write("patch 55 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
                 elif H.edges[ei]['btype'] == 'beta-5':
                     if H.nodes[ei[0]]['mtype'] == 'H':
                         fout.write("patch B5P %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
@@ -956,7 +949,7 @@ class Polymer(PolymerGraph):
                 elif H.edges[ei]['btype'] == 'beta-beta':
                     fout.write("patch BB %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
                 elif H.edges[ei]['btype'] == 'beta-1':
-                    fout.write("patch B1 %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
+                    fout.write("patch B1 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
             fout.write("writepsf %s.psf\n" % segname)
 
 

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -424,7 +424,7 @@ class Polymer(PolymerGraph):
 
         # Add the edges to monomer nodes
         print(linkage_new_name, M1_index, M2_index)
-        if linkage[0] <= linkage[1]:
+        if linkage_index[0] <= linkage_index[1]:
             self.bigG.add_edges_from([(M1_index, M2_index)], btype=linkage_new_name)
         else:
             self.bigG.add_edges_from([(M2_index, M1_index)], btype=linkage_new_name)

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -2,7 +2,7 @@
 Build lignin polymers
 """
 import networkx as nx
-
+import os
 from typing import Optional, TypeVar, Union, Tuple, List
 from copy import copy
 import warnings

--- a/ligning/polymer.py
+++ b/ligning/polymer.py
@@ -896,6 +896,67 @@ class Polymer(PolymerGraph):
         
         return new_linkage_flag
 
+    def write_LigninBuilder( name: Optional[str]='test',
+        segname: Optional[str]='L',
+        save_path: Optional[str]=os.getcwd()) -> None:
+        """Convert this polymer to a Tcl script that VMD and LigninBuilder can convert to a 3D structure
+
+        Parameters
+        ----------
+        name : Optional[str], optional
+            name of the file to be written without the .tcl extension, by default 'test', creating a 'test.tcl' file
+        segname : Optional[str], optional
+            segment name created. Default is "L"
+        save_path : Optional[str], optional
+            path to save the figure, by default os.getcwd()
+        """ 
+        H = self.bigG
+        if not os.path.exists(save_path):
+            os.mkdir(save_path)
+        filename = os.path.join(save_path, name+'.tcl')
+        with open(filename, 'w') as fout:
+            fout.write("package require psfgen\ntopology toppar/top_all36_cgenff.rtf\ntopology toppar/top_lignin.top\n"
+               "topology toppar/top_spirodienone.top\n")
+            # Write monomers
+            fout.write("resetpsf\nsegment %s {\n" % segname)
+            for i in range(len(G.nodes)):
+                if H.nodes[i]['mtype'] == 'G':
+                    monomer = "GUAI"
+                elif H.nodes[i]['mtype'] == 'C':
+                    monomer = "CAT"
+                elif H.nodes[i]['mtype'] == 'H':
+                    monomer = "PHP"
+                elif H.nodes[i]['mtype'] == 'S':
+                    monomer = "SYR"
+                else:
+                    raise ValueError("Monomer type not allowed. Must input C, H, G or S.")
+                fout.write("residue %d %s\n" % (i+1, monomer))
+            fout.write("}\n")
+            #Write linkages
+            for ei in list(H.edges):
+                #ei will be the tuple describing the nodes that are connected.
+                #The order is important! The first node is the residue with the lower numbered carbon involved in the linkage.
+                #Based on the patches used by LigninBuilder, sometimes the "first" residue in the patch is the first residue in the graph, and sometimes its the second.
+                if H.edges[ei]['btype'] == '4-O-5':
+                    fout.write("patch 4O5 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
+                elif H.edges[ei]['btype'] == 'alpha-O-4':
+                    fout.write("patch AO4 %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
+                elif H.edges[ei]['btype'] == 'beta-O-4':
+                    fout.write("patch BO4 %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
+                elif H.edges[ei]['btype'] == '5-5':
+                    fout.write("patch 55 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
+                elif H.edges[ei]['btype'] == '5-5':
+                    fout.write("patch 55 %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
+                elif H.edges[ei]['btype'] == 'beta-5':
+                    if H.nodes[ei[0]]['mtype'] == 'H':
+                        fout.write("patch B5P %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
+                    else:
+                        fout.write("patch B5%s %s:%s %s:%s\n" % (H.nodes[ei[0]]['mtype'], segname, ei[1]+1, segname, ei[0]+1))
+                elif H.edges[ei]['btype'] == 'beta-beta':
+                    fout.write("patch BB %s:%s %s:%s\n" % (segname, ei[0]+1, segname, ei[1]+1))
+                elif H.edges[ei]['btype'] == 'beta-1':
+                    fout.write("patch B1 %s:%s %s:%s\n" % (segname, ei[1]+1, segname, ei[0]+1))
+            fout.write("writepsf %s.psf\n" % segname)
 
 
                

--- a/ligning/utils.py
+++ b/ligning/utils.py
@@ -203,11 +203,6 @@ def graph_to_mol(
         Chem.Draw.MolToFile(mol, filename, size=(500, 500))
     
     return mol
-    
-def graph_to_LigninBuilder(G: nxgraph, 
-    name: Optional[str]='test',
-    save_path: Optional[str]=os.getcwd()):
-    #G.nodes() should list the monomers. That needs to be written first
 
 def smiles_to_formula(smiles: str) -> str:
     """Convert the smiles to the chemical formula in C, H and O

--- a/ligning/utils.py
+++ b/ligning/utils.py
@@ -93,6 +93,46 @@ def draw_big_graph(G: nxgraph) -> None:
     # big graph is marked by hexagons 
     draw_graph(G, node_labels, node_shape = 'h', node_size=1000)
 
+def write_big_graph_LigninBuilder(G: nxgraph,
+    name: Optional[str]='test',
+    save_path: Optional[str]=os.getcwd()) -> None:
+    """Convert the big graph to a Tcl script that VMD and LigninBuilder can convert to a structure
+
+    Parameters
+    ----------
+    G : nxgraph
+        a connected graph, each node is a monomer, edges are linkages
+    name : Optional[str], optional
+        name of the file to be written without the .tcl extension, by default 'test', creating a 'test.tcl' file
+    segname : Optional[str], optional
+        segment name created.
+    save_path : Optional[str], optional
+        path to save the figure, by default os.getcwd()
+    """ 
+    if not os.path.exists(save_path):
+        os.mkdir(save_path)
+    filename = os.path.join(save_path, name+'.tcl')
+    with open(filename, 'w') as fout:
+        fout.write("package require psfgen\ntopology toppar/top_all36_cgenff.rtf\ntopology toppar/top_lignin.top\n"
+           "topology toppar/top_spirodienone.top\n")
+        # Write monomers
+        fout.write("resetpsf\nsegment %s {\n" % segname)
+        for i in range(len(G.nodes)):
+            if G.nodes[i]['mtype'] == 'G':
+                monomer = "GUAI"
+            elif G.nodes[i]['mtype'] == 'C':
+                monomer = "CAT"
+            elif G.nodes[i]['mtype'] == 'H':
+                monomer = "PHP"
+            elif G.nodes[i]['mtype'] == 'S':
+                monomer = "SYR"
+            else:
+                raise ValueError("Monomer type not allowed. Must input C, H, G or S.")
+            fout.write("residue %d %s\n" % (i+1, monomer))
+        fout.write("}\n")
+        for i in range(len(G.edges)):
+            print(G.edges[i], G.edges[i]['btype'])
+        #fout.write("patch %s %s:%s %s:%s\n" % (patch, segname, i+1, segname, j+1))
 
 def draw_atomic_graph(G: nxgraph) -> None:
     """Plot the atomic graph
@@ -164,7 +204,10 @@ def graph_to_mol(
     
     return mol
     
-
+def graph_to_LigninBuilder(G: nxgraph, 
+    name: Optional[str]='test',
+    save_path: Optional[str]=os.getcwd()):
+    #G.nodes() should list the monomers. That needs to be written first
 
 def smiles_to_formula(smiles: str) -> str:
     """Convert the smiles to the chemical formula in C, H and O

--- a/ligning/utils.py
+++ b/ligning/utils.py
@@ -93,47 +93,6 @@ def draw_big_graph(G: nxgraph) -> None:
     # big graph is marked by hexagons 
     draw_graph(G, node_labels, node_shape = 'h', node_size=1000)
 
-def write_big_graph_LigninBuilder(G: nxgraph,
-    name: Optional[str]='test',
-    save_path: Optional[str]=os.getcwd()) -> None:
-    """Convert the big graph to a Tcl script that VMD and LigninBuilder can convert to a structure
-
-    Parameters
-    ----------
-    G : nxgraph
-        a connected graph, each node is a monomer, edges are linkages
-    name : Optional[str], optional
-        name of the file to be written without the .tcl extension, by default 'test', creating a 'test.tcl' file
-    segname : Optional[str], optional
-        segment name created.
-    save_path : Optional[str], optional
-        path to save the figure, by default os.getcwd()
-    """ 
-    if not os.path.exists(save_path):
-        os.mkdir(save_path)
-    filename = os.path.join(save_path, name+'.tcl')
-    with open(filename, 'w') as fout:
-        fout.write("package require psfgen\ntopology toppar/top_all36_cgenff.rtf\ntopology toppar/top_lignin.top\n"
-           "topology toppar/top_spirodienone.top\n")
-        # Write monomers
-        fout.write("resetpsf\nsegment %s {\n" % segname)
-        for i in range(len(G.nodes)):
-            if G.nodes[i]['mtype'] == 'G':
-                monomer = "GUAI"
-            elif G.nodes[i]['mtype'] == 'C':
-                monomer = "CAT"
-            elif G.nodes[i]['mtype'] == 'H':
-                monomer = "PHP"
-            elif G.nodes[i]['mtype'] == 'S':
-                monomer = "SYR"
-            else:
-                raise ValueError("Monomer type not allowed. Must input C, H, G or S.")
-            fout.write("residue %d %s\n" % (i+1, monomer))
-        fout.write("}\n")
-        for i in range(len(G.edges)):
-            print(G.edges[i], G.edges[i]['btype'])
-        #fout.write("patch %s %s:%s %s:%s\n" % (patch, segname, i+1, segname, j+1))
-
 def draw_atomic_graph(G: nxgraph) -> None:
     """Plot the atomic graph
 

--- a/ligning/utils.py
+++ b/ligning/utils.py
@@ -34,7 +34,7 @@ nparray = TypeVar('nparray')
 import matplotlib
 if platform.system() == 'Linux':
     matplotlib.use('Agg')
-    print('switched')
+    #print('switched')
 import matplotlib.pyplot as plt   
 # if platform.system() == 'Linux':
 #     plt.switch_backend('agg')


### PR DESCRIPTION
Rather than going through the SMILES export, this is what needed to change in order to export the graph to inputs that LigninBuilder can handle. There is one big thing that I had to change, namely making `bigG` a directional graph from the original undirected graph. For building 3D structures, LigninBuilder links together monomers, but needs to be able to keep track of the directionality of the interaction. For undirected graphs, the edges are sorted, and the directionality is lost. The directionality is determined by the changes inside `update_units`, namely sorting the linkage indices. Comparing the linkage indices against the patches that apply the linkages in CHARMM gives us a straightforward output method.